### PR TITLE
Fix: Reliability

### DIFF
--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -577,7 +577,7 @@ public:
       },
       this->sdo_timeout,
       ec);
-    if (ec) throw lely::canopen::SdoError(0, data.index_, data.subindex_, ec, "LelyDriverBridge::async_sdo_read_typed");
+    if (ec) throw lely::canopen::SdoError(0, idx, subidx, ec, "LelyDriverBridge::async_sdo_read_typed");
     return prom->get_future();
   }
 

--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -446,7 +446,7 @@ public:
     std::unique_lock<std::mutex> lck(sdo_mutex);
     if (running)
     {
-      sdo_cond.wait(lck);
+      sdo_cond.wait_for(lck, this->sdo_timeout);
     }
     running = true;
 
@@ -532,7 +532,7 @@ public:
     std::unique_lock<std::mutex> lck(sdo_mutex);
     if (running)
     {
-      sdo_cond.wait(lck);
+      sdo_cond.wait_for(lck, this->sdo_timeout);
     }
     running = true;
 
@@ -682,7 +682,7 @@ public:
       return true;
     }
     std::unique_lock<std::mutex> lck(boot_mtex);
-    boot_cond.wait_for(lck, boot_timeout);
+    boot_cond.wait_for(lck, this->boot_timeout);
     if ((boot_status != 0) && (boot_status != 'L'))
     {
       throw std::system_error(boot_status, LelyBridgeErrCategory(), "Boot Issue");

--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -555,6 +555,7 @@ public:
       this->sdo_cond.notify_one();
       return prom->get_future();
     }
+    ::std::error_code ec;
     this->SubmitRead<T>(
       idx, subidx,
       [this, prom](uint8_t id, uint16_t idx, uint8_t subidx, ::std::error_code ec, T value) mutable
@@ -574,7 +575,9 @@ public:
         this->running = false;
         this->sdo_cond.notify_one();
       },
-      this->sdo_timeout);
+      this->sdo_timeout,
+      ec);
+    if (ec) throw lely::canopen::SdoError(0, data.index_, data.subindex_, ec, "LelyDriverBridge::async_sdo_read_typed");
     return prom->get_future();
   }
 
@@ -748,6 +751,7 @@ public:
   template <typename T>
   void submit_read(COData data)
   {
+    ::std::error_code ec;
     this->SubmitRead<T>(
       data.index_, data.subindex_,
       [this](uint8_t id, uint16_t idx, uint8_t subidx, ::std::error_code ec, T value) mutable
@@ -769,7 +773,9 @@ public:
         this->running = false;
         this->sdo_cond.notify_one();
       },
-      this->sdo_timeout);
+      this->sdo_timeout,
+      ec);
+    if (ec) throw lely::canopen::SdoError(0, data.index_, data.subindex_, ec, "LelyDriverBridge::submit_read");
   }
 
   template <typename T>

--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -183,7 +183,7 @@ std::future<bool> LelyDriverBridge::async_sdo_write(COData data)
   std::unique_lock<std::mutex> lck(sdo_mutex);
   if (running)
   {
-    sdo_cond.wait(lck);
+    sdo_cond.wait_for(lck, this->sdo_timeout);
   }
   running = true;
 
@@ -242,7 +242,7 @@ std::future<COData> LelyDriverBridge::async_sdo_read(COData data)
   std::unique_lock<std::mutex> lck(sdo_mutex);
   if (running)
   {
-    sdo_cond.wait(lck);
+    sdo_cond.wait_for(lck, this->sdo_timeout);
   }
   running = true;
 

--- a/canopen_master_driver/include/canopen_master_driver/lely_master_bridge.hpp
+++ b/canopen_master_driver/include/canopen_master_driver/lely_master_bridge.hpp
@@ -49,6 +49,7 @@ class LelyMasterBridge : public lely::canopen::AsyncMaster
   bool running;                      ///< Bool to indicate whether an sdo call is running
   std::condition_variable sdo_cond;  ///< Condition variable to sync service calls (one at a time)
   uint8_t node_id;                   ///< Node id of the master
+  std::chrono::milliseconds sdo_timeout;
 
 public:
   /**
@@ -63,8 +64,9 @@ public:
    */
   LelyMasterBridge(
     ev_exec_t * exec, lely::io::TimerBase & timer, lely::io::CanChannelBase & chan,
-    const std::string & dcf_txt, const std::string & dcf_bin = "", uint8_t id = (uint8_t)255U)
-  : lely::canopen::AsyncMaster(exec, timer, chan, dcf_txt, dcf_bin, id), node_id(id)
+    const std::string & dcf_txt, const std::string & dcf_bin = "", uint8_t id = (uint8_t)255U, 
+    std::chrono::milliseconds timeout = 20ms)
+  : lely::canopen::AsyncMaster(exec, timer, chan, dcf_txt, dcf_bin, id), node_id(id), sdo_timeout(timeout)
   {
   }
 

--- a/canopen_master_driver/src/lely_master_bridge.cpp
+++ b/canopen_master_driver/src/lely_master_bridge.cpp
@@ -25,7 +25,7 @@ std::future<bool> LelyMasterBridge::async_write_sdo(uint8_t id, COData data, uin
   std::unique_lock<std::mutex> lck(sdo_mutex);
   if (running)
   {
-    sdo_cond.wait(lck);
+    sdo_cond.wait_for(lck, this->sdo_timeout);
   }
   running = true;
 
@@ -72,7 +72,7 @@ std::future<COData> LelyMasterBridge::async_read_sdo(uint8_t id, COData data, ui
   std::unique_lock<std::mutex> lck(sdo_mutex);
   if (running)
   {
-    sdo_cond.wait(lck);
+    sdo_cond.wait_for(lck, this->sdo_timeout);
   }
   running = true;
 

--- a/lely_core_libraries/CMakeLists.txt
+++ b/lely_core_libraries/CMakeLists.txt
@@ -10,8 +10,8 @@ ExternalProject_Add(upstr_lely_core_libraries    # Name for custom target
   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/upstream
   INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"  # Installation prefix
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build
-  GIT_REPOSITORY https://gitlab.com/lely_industries/lely-core.git
-  GIT_TAG fb735b79cab5f0cdda45bc5087414d405ef8f3ab
+  GIT_REPOSITORY https://github.com/luis-camero/lely-core.git
+  GIT_TAG fix/catch-set-time
   TIMEOUT 60
   #UPDATE step apply patch to fix dcf-tools install
   UPDATE_COMMAND

--- a/lely_core_libraries/CMakeLists.txt
+++ b/lely_core_libraries/CMakeLists.txt
@@ -10,8 +10,8 @@ ExternalProject_Add(upstr_lely_core_libraries    # Name for custom target
   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/upstream
   INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"  # Installation prefix
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build
-  GIT_REPOSITORY https://github.com/luis-camero/lely-core.git
-  GIT_TAG fix/catch-set-time
+  GIT_REPOSITORY https://github.com/clearpathrobotics/lely-core.git
+  GIT_TAG master
   TIMEOUT 60
   #UPDATE step apply patch to fix dcf-tools install
   UPDATE_COMMAND


### PR DESCRIPTION
Pass error code to LelyDriverBridge to use overloaded `SubmitRead` function that will not throw an exception and that will instead return the error code to be handled externally. 

Add timeout to conditional variable waits to prevent endless waits for a read that will never/cannot occur. 

Switch `lely-core` repository to [clearpathrobotics/lely-core](https://github.com/clearpathrobotics/lely-core) to get fixes we've introduced.